### PR TITLE
Fix code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/src/SqlAccountRestAPI/Controllers/HistoryController.cs
+++ b/src/SqlAccountRestAPI/Controllers/HistoryController.cs
@@ -34,9 +34,9 @@ public class HistoryController(ILogger<HistoryController> logger) : ControllerBa
     [HttpGet("log-detail")]
     public IActionResult GetLogFileContent([FromQuery(Name = "fn")][Required] string fileName)
     {
-        if (string.IsNullOrEmpty(fileName))
+        if (string.IsNullOrEmpty(fileName) || fileName.Contains("..") || fileName.Contains("/") || fileName.Contains("\\"))
         {
-            return BadRequest($"Filename (fileName) is required.");
+            return BadRequest($"Invalid filename (fileName).");
         }
 
         // Get the current working directory
@@ -59,9 +59,9 @@ public class HistoryController(ILogger<HistoryController> logger) : ControllerBa
     [HttpGet("download")]
     public IActionResult Download([FromQuery(Name = "fn")][Required] string fileName)
     {
-        if (string.IsNullOrEmpty(fileName))
+        if (string.IsNullOrEmpty(fileName) || fileName.Contains("..") || fileName.Contains("/") || fileName.Contains("\\"))
         {
-            return BadRequest($"Filename (fileName) is required.");
+            return BadRequest($"Invalid filename (fileName).");
         }
 
         // Get the current working directory


### PR DESCRIPTION
Fixes [https://github.com/beehexacorp/sql-account-rest-api/security/code-scanning/4](https://github.com/beehexacorp/sql-account-rest-api/security/code-scanning/4)

To fix the problem, we need to validate the `fileName` parameter to ensure it does not contain any path traversal characters or separators. This can be done by checking for the presence of "..", "/", and "\\" in the `fileName`. If any of these characters are found, we should return a bad request response. This validation should be added to both the `GetLogFileContent` and `Download` methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
